### PR TITLE
OSRM 데모버전을 이용해 도보 경로를 받아오는 API 구현

### DIFF
--- a/Docker/api_gateway/convertWalkData.js
+++ b/Docker/api_gateway/convertWalkData.js
@@ -1,0 +1,42 @@
+const axios = require("axios");
+const { decodePolyline } = require("./decodePolyline");
+
+const options = {
+  overview: false,
+  steps: true,
+};
+
+async function GetWalk(sLat, sLon, eLat, eLon) {
+  const url = `https://routing.openstreetmap.de/routed-foot/route/v1/foot/${sLat},${sLon};${eLat},${eLon}`;
+
+  // 직접 build할때 사용, 실행시 매번 (https://ea51-211-201-168-202.ngrok-free.app) 변경해야함
+  // 추후 개선 예정
+  // const url = `https://ea51-211-201-168-202.ngrok-free.app/route/v1/foot/${sLat},${sLon};${eLat},${eLon}`;
+
+  try {
+    const response = await axios.get(url, { params: options });
+
+    const { routes } = response.data;
+    const { totalDistance, totalTime, steps } = {
+      totalDistance: routes[0]?.distance || [],
+      totalTime: routes[0]?.duration || [],
+      steps: routes[0]?.legs[0]?.steps || [],
+    };
+
+    let totalWalkLanLon = [];
+    for (const step of steps) {
+      let walkLanLons = decodePolyline(step.geometry);
+      for (const walkLanLon of walkLanLons) {
+        totalWalkLanLon.push(walkLanLon);
+      }
+    }
+
+    return totalWalkLanLon;
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+module.exports = {
+  GetWalk: GetWalk,
+};

--- a/Docker/api_gateway/decodePolyline.js
+++ b/Docker/api_gateway/decodePolyline.js
@@ -1,0 +1,41 @@
+function decodePolyline(encoded) {
+  let index = 0;
+  let lat = 0;
+  let lng = 0;
+  let coordinates = [];
+
+  while (index < encoded.length) {
+    let shift = 0;
+    let result = 0;
+    let byte;
+
+    do {
+      byte = encoded.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+
+    let dlat = result & 1 ? ~(result >> 1) : result >> 1;
+    lat += dlat;
+
+    shift = 0;
+    result = 0;
+
+    do {
+      byte = encoded.charCodeAt(index++) - 63;
+      result |= (byte & 0x1f) << shift;
+      shift += 5;
+    } while (byte >= 0x20);
+
+    let dlng = result & 1 ? ~(result >> 1) : result >> 1;
+    lng += dlng;
+
+    coordinates.push([lat * 1e-5, lng * 1e-5]);
+  }
+
+  return coordinates;
+}
+
+module.exports = {
+  decodePolyline: decodePolyline,
+};

--- a/Docker/api_gateway/routes/api.js
+++ b/Docker/api_gateway/routes/api.js
@@ -5,11 +5,12 @@ const dotenv = require("dotenv");
 const axios = require("axios");
 
 const { GetRoot } = require("../public_transport.js");
+const { GetWalk } = require("../convertWalkData.js");
 
 dotenv.config({ path: path.join(__dirname, "../Keys/.env") });
 
 router.get("/POI", async (req, res) => {
-  input = req.query;
+  const input = req.query;
   const url = `https://dapi.kakao.com/v2/local/search/keyword.json?query=${encodeURIComponent(
     input.query
   )}`;
@@ -43,6 +44,13 @@ router.get("/Odsay", async (req, res) => {
     endPoint.end_lat
   );
   return res.send(Routes);
+});
+
+router.get("/osrm", async (req, res) => {
+  const { sLat, sLon, eLat, eLon } = req.query;
+  const walkData = await GetWalk(sLat, sLon, eLat, eLon);
+
+  return res.send(walkData);
 });
 
 module.exports = router;

--- a/Docker/api_gateway/swagger/swagger.js
+++ b/Docker/api_gateway/swagger/swagger.js
@@ -81,6 +81,73 @@ const apiPaths = {
       },
     },
   },
+  "/api/osrm/": {
+    get: {
+      summary: "OSRM으로 도보경로 요청하기",
+      description:
+        "위도: lan, 경도 : lon<br>출발지의 위경도, 도착지의 위경도를 입력하여 도보경로를 받아옵니다.",
+      parameters: [
+        {
+          in: "query",
+          name: "sLat",
+          description: "출발지 위도",
+          required: true,
+          schema: {
+            type: "string",
+            example: 126.9594,
+          },
+        },
+        {
+          in: "query",
+          name: "sLon",
+          description: "출발지 경도",
+          required: true,
+          schema: {
+            type: "string",
+            example: 37.4945,
+          },
+        },
+        {
+          in: "query",
+          name: "eLat",
+          description: "도착지 위도",
+          required: true,
+          schema: {
+            type: "string",
+            example: 126.96,
+          },
+        },
+        {
+          in: "query",
+          name: "eLon",
+          description: "도착지 경도",
+          required: true,
+          schema: {
+            type: "string",
+            example: 37.5068,
+          },
+        },
+      ],
+      responses: {
+        200: {
+          description: "도보경로는 [위도(lon), 경도(lat)] 형식의 배열로 구성되어 있습니다",
+          content: {
+            "application/json": {
+              items: {
+                type: "number",
+                description: "위도, 경도",
+              },
+              example: [
+                [37.49448, 126.95942000000001],
+                [37.4945, 126.95946],
+                [37.49492, 126.95954],
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
 };
 
 const options = {


### PR DESCRIPTION
## 커밋 메시지
- api.js : "/osrm" controller 추가
- convertWalkData.js : 출발지의 위경도, 도착지의 위경도를 입력받아 [위도, 경도]로 구성된 배열을 리턴하는 함수 구현
- decodePolyline.js : encoding된 polyline을 decoding하는 함수 구현
- swagger.js : "/osrm" 엔드포인트에 대한 정보 추가
## 추가 설명
- OSRM에서 제공해주는 데모 서버([url](https://router.project-osrm.org/route/v1/driving/13.388860,52.517037;13.397634,52.529407;13.428555,52.523219?overview=false&steps=true))를 대체할 뽀송길에 적합한 도보 알고리즘을 구현한뒤, Mac 또는 AWS에서 직접 빌드후 배포하는 서버로 대체할 예정
- OSRM은 도보 경로를 인코딩한 polyline 형태로 제공해준다. 이를 디코딩하면 [위도, 경도] 데이터를 확인할 수 있습니다. 
- 인코딩된 형태
   <img width="620" alt="image" src="https://github.com/Gonagi/pposonggil_v2/assets/50358403/fcef98be-1a97-45c2-9eed-796f0c473ebb">
- 디코딩한 결과
   <img width="672" alt="image" src="https://github.com/Gonagi/pposonggil_v2/assets/50358403/1ca027a6-9b09-472c-9e2c-793d6c670ae3">
- 서버를 실행한 후 <https://localhost/api_gateway>에 접속하면 osrm API에 대한 swagger 문서를 확인할 수 있습니다.
- 우측 상단에 위치한 'try it out'으로 API를 호출하고 응답을 확인할 수 있습니다.
   <img width="707" alt="image" src="https://github.com/Gonagi/pposonggil_v2/assets/50358403/dae5a8e9-70f8-4ef2-a46d-0a35f3289e87">
