### PR TITLE
[24.03.01] GitHub Actions 개선 & 이미지 pull 문제 해결 

### DIFF
--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Build and push api_gateway image
         run: |
           cd Docker/api_gateway
-          docker build -t ${{secrets.DOCKER_REPO}}/api_gateway:latest .
-          docker push ${{secrets.DOCKER_REPO}}/api_gateway:latest
+          docker build -t ${{secrets.DOCKER_REPO}}/api_gateway:0.62
+          docker push ${{secrets.DOCKER_REPO}}/api_gateway:0.62
   build_and_push_mysql:
     needs: setup
     runs-on: ubuntu-latest
@@ -73,8 +73,8 @@ jobs:
       - name: Build and push mysql image
         run: |
           docker pull mysql:8
-          docker tag mysql:8 ${{secrets.DOCKER_REPO}}/mysql:8
-          docker push ${{secrets.DOCKER_REPO}}/mysql:8
+          docker tag mysql:8 ${{secrets.DOCKER_REPO}}/mysql:0.62
+          docker push ${{secrets.DOCKER_REPO}}/mysql:0.62
   build_and_push_nginx:
     needs: setup
     runs-on: ubuntu-latest
@@ -87,8 +87,8 @@ jobs:
       - name: Build and push nginx image
         run: |
           docker pull nginx:1.25
-          docker tag nginx:1.25 ${{secrets.DOCKER_REPO}}/nginx:1.25
-          docker push ${{secrets.DOCKER_REPO}}/nginx:1.25
+          docker tag nginx:1.25 ${{secrets.DOCKER_REPO}}/nginx:0.62
+          docker push ${{secrets.DOCKER_REPO}}/nginx:0.62
   Deploy_to_server:
     needs:
       [

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -112,7 +112,7 @@ jobs:
             cd Docker/Keys
             echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
             echo "${{secrets.GONAGI_STORE_KEY_PEM}}" >> gonagi.store-key.pem
-            jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > Docker/Keys/.env
+            jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
             cd ../server
             sudo npm install
             cd ../api_gateway

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -113,8 +113,8 @@ jobs:
             echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
             echo "${{secrets.GONAGI_STORE_KEY_PEM}}" >> gonagi.store-key.pem
             jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
-            cd ../server
-            sudo npm install
-            cd ../api_gateway
-            sudo npm install
+            sudo docker pull ${{secrets.DOCKER_REPO}}/api_gateway:0.62
+            sudo docker pull ${{secrets.DOCKER_REPO}}/server:0.62
+            sudo docker pull ${{secrets.DOCKER_REPO}}/nginx:0.62
+            sudo docker pull ${{secrets.DOCKER_REPO}}/mysql:0.62
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -1,11 +1,9 @@
 name: CI/CD
 
 on:
-  push:
-    branches: 
-      - main
-      - develop
   pull_request:
+    branches:
+      - develop
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -68,42 +66,8 @@ jobs:
           cd Docker/api_gateway
           docker build -t ${{secrets.DOCKER_REPO}}/api_gateway:latest .
           docker push ${{secrets.DOCKER_REPO}}/api_gateway:latest
-  build_and_push_mysql:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Docker token
-        uses: actions/download-artifact@v4.1.1
-        with:
-          name: docker-token
-          path: ~/.docker/
-      - name: Build and push mysql image
-        run: |
-          docker pull mysql:8
-          docker tag mysql:8 ${{secrets.DOCKER_REPO}}/mysql:8
-          docker push ${{secrets.DOCKER_REPO}}/mysql:8
-  build_and_push_nginx:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Docker token
-        uses: actions/download-artifact@v4.1.1
-        with:
-          name: docker-token
-          path: ~/.docker/
-      - name: Build and push nginx image
-        run: |
-          docker pull nginx:1.25
-          docker tag nginx:1.25 ${{secrets.DOCKER_REPO}}/nginx:1.25
-          docker push ${{secrets.DOCKER_REPO}}/nginx:1.25
   Deploy_to_server:
-    needs:
-      [
-        build_and_push_server,
-        build_and_push_api_gateway,
-        build_and_push_mysql,
-        build_and_push_nginx,
-      ]
+    needs: [build_and_push_server, build_and_push_api_gateway]
     runs-on: ubuntu-latest
     steps:
       - name: executing remote ssh commands using password
@@ -116,7 +80,7 @@ jobs:
           script: |
             sudo rm -rf pposonggil_v2
             git clone https://github.com/Gonagi/pposonggil_v2.git 
-                        cd pposonggil_v2
+            cd pposonggil_v2
             sudo find . -type f -exec sed -i 's/localhost/gonagi.store/g' {} +   
             cd Docker/Keys
             echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
@@ -137,10 +101,10 @@ jobs:
             sudo npm install
             sudo docker rmi ${{secrets.DOCKER_REPO}}/api_gateway:latest
             sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/nginx:1.25
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/mysql:8
+            sudo docker rmi nginx:1.25
+            sudo docker rmi mysql:8
             sudo docker pull ${{secrets.DOCKER_REPO}}/api_gateway:latest
             sudo docker pull ${{secrets.DOCKER_REPO}}/server:latest
-            sudo docker pull ${{secrets.DOCKER_REPO}}/nginx:1.25
-            sudo docker pull ${{secrets.DOCKER_REPO}}/mysql:8 
+            sudo docker pull nginx:1.25
+            sudo docker pull mysql:8 
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -77,14 +77,12 @@ jobs:
             git clone https://Gonagi:${{secrets.GONAGI_TOKEN}}@github.com/Gonagi/pposonggil_v2.git
             cd pposonggil_v2
             sudo find . -type f -exec sed -i 's/localhost/gonagi.store/g' {} + 
-            cd Docker/server
-            sudo npm install
-            cd ../api_gateway
-            sudo npm install
-            cd ../Keys
-            GONAGI_STORE_PEM="${{secrets.GONAGI_STORE_PEM}}"
-            GONAGI_STORE_KEY_PEM="${{secrets.GONAGI_STORE_KEY_PEM}}"
-            echo "$GONAGI_STORE_PEM" > gonagi.store.pem
-            echo "$GONAGI_STORE_KEY_PEM" > gonagi.store-key.pem
+            cd /Keys
+            echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
+            echo "${{secrets.GONAGI_STORE_KEY_PEM}}" >> gonagi.store-key.pem
             jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
+            sudo docker rmi ${{secrets.DOCKER_REPO}}/api_gateway:latest
+            sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
+            sudo docker rmi nginx:1.25
+            sudo docker rmi mysql:8
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -108,7 +108,7 @@ jobs:
           port: ${{secrets.AWS_PORT}}
           script: |
             sudo rm -rf pposonggil_v2
-            git clone https://Gonagi:${{secrets.GONAGI_TOKEN}}@github.com/Gonagi/pposonggil_v2.git
+            git clone https://github.com/Gonagi/pposonggil_v2.git
             cd pposonggil_v2
             sudo find . -type f -exec sed -i 's/localhost/gonagi.store/g' {} + 
             cd Docker/Keys
@@ -123,4 +123,8 @@ jobs:
             sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
             sudo docker rmi ${{secrets.DOCKER_REPO}}/nginx:1.25
             sudo docker rmi ${{secrets.DOCKER_REPO}}/mysql:8
+            sudo docker pull ${{secrets.DOCKER_REPO}}/api_gateway:latest
+            sudo docker pull ${{secrets.DOCKER_REPO}}/server:latest
+            sudo docker pull ${{secrets.DOCKER_REPO}}/nginx:1.25
+            sudo docker pull ${{secrets.DOCKER_REPO}}/mysql:8 
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -42,8 +42,8 @@ jobs:
           path: ~/.docker/
       - name: Build and push server image
         run: |
-          docker buildx build -t ${{secrets.DOCKER_REPO}}/server:0.62 Docker/server
-          docker push ${{secrets.DOCKER_REPO}}/server:0.62
+          docker buildx build -t ${{secrets.DOCKER_REPO}}/server:latest Docker/server
+          docker push ${{secrets.DOCKER_REPO}}/server:latest
   build_and_push_api_gateway:
     needs: setup
     runs-on: ubuntu-latest
@@ -57,8 +57,8 @@ jobs:
           path: ~/.docker/
       - name: Build and push api_gateway image
         run: |
-          docker buildx build -t ${{secrets.DOCKER_REPO}}/api_gateway:0.62 Docker/api_gateway
-          docker push ${{secrets.DOCKER_REPO}}/api_gateway:0.62
+          docker buildx build -t ${{secrets.DOCKER_REPO}}/api_gateway:latest Docker/api_gateway
+          docker push ${{secrets.DOCKER_REPO}}/api_gateway:latest
   build_and_push_mysql:
     needs: setup
     runs-on: ubuntu-latest
@@ -71,8 +71,8 @@ jobs:
       - name: Build and push mysql image
         run: |
           docker pull mysql:8
-          docker tag mysql:8 ${{secrets.DOCKER_REPO}}/mysql:0.62
-          docker push ${{secrets.DOCKER_REPO}}/mysql:0.62
+          docker tag mysql:8 ${{secrets.DOCKER_REPO}}/mysql:8
+          docker push ${{secrets.DOCKER_REPO}}/mysql:8
   build_and_push_nginx:
     needs: setup
     runs-on: ubuntu-latest
@@ -85,8 +85,8 @@ jobs:
       - name: Build and push nginx image
         run: |
           docker pull nginx:1.25
-          docker tag nginx:1.25 ${{secrets.DOCKER_REPO}}/nginx:0.62
-          docker push ${{secrets.DOCKER_REPO}}/nginx:0.62
+          docker tag nginx:1.25 ${{secrets.DOCKER_REPO}}/nginx:1.25
+          docker push ${{secrets.DOCKER_REPO}}/nginx:1.25
   Deploy_to_server:
     needs:
       [
@@ -117,4 +117,12 @@ jobs:
             sudo npm install
             cd ../api_gateway
             sudo npm install
+            sudo docker rmi ${{secrets.DOCKER_REPO}}/api_gateway:latest
+            sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
+            sudo docker rmi ${{secrets.DOCKER_REPO}}/nginx:1.25
+            sudo docker rmi ${{secrets.DOCKER_REPO}}/mysql:8
+            sudo docker pull ${{secrets.DOCKER_REPO}}/api_gateway:latest
+            sudo docker pull ${{secrets.DOCKER_REPO}}/server:latest
+            sudo docker pull ${{secrets.DOCKER_REPO}}/nginx:1.25
+            sudo docker pull ${{secrets.DOCKER_REPO}}/mysql:8 
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -113,8 +113,8 @@ jobs:
             echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
             echo "${{secrets.GONAGI_STORE_KEY_PEM}}" >> gonagi.store-key.pem
             jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
-            sudo docker pull ${{secrets.DOCKER_REPO}}/api_gateway:0.62
-            sudo docker pull ${{secrets.DOCKER_REPO}}/server:0.62
-            sudo docker pull ${{secrets.DOCKER_REPO}}/nginx:0.62
-            sudo docker pull ${{secrets.DOCKER_REPO}}/mysql:0.62
+            cd ../server
+            sudo npm install
+            cd ../api_gateway
+            sudo npm install
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -1,12 +1,10 @@
 name: CI/CD
 
 on:
-  # pull_request:
-  #   branches:
-  #     - main
-  push:
+  pull_request:
     branches:
-      - feature-CICD
+      - main
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -130,8 +130,5 @@ jobs:
             sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
             sudo docker rmi ${{secrets.DOCKER_REPO}}/nginx:1.25
             sudo docker rmi ${{secrets.DOCKER_REPO}}/mysql:8
-            sudo docker pull ${{secrets.DOCKER_REPO}}/api_gateway:latest
-            sudo docker pull ${{secrets.DOCKER_REPO}}/server:latest
-            sudo docker pull ${{secrets.DOCKER_REPO}}/nginx:1.25
-            sudo docker pull ${{secrets.DOCKER_REPO}}/mysql:8 
+            sudo docker-compose pull
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -77,7 +77,7 @@ jobs:
             git clone https://Gonagi:${{secrets.GONAGI_TOKEN}}@github.com/Gonagi/pposonggil_v2.git
             cd pposonggil_v2
             sudo find . -type f -exec sed -i 's/localhost/gonagi.store/g' {} + 
-            cd /Keys
+            cd Docker/Keys
             echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
             echo "${{secrets.GONAGI_STORE_KEY_PEM}}" >> gonagi.store-key.pem
             jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Build and push server image
         run: |
           cd Docker/server
-          docker build -t ${{secrets.DOCKER_REPO}}/server:latest .
-          docker push ${{secrets.DOCKER_REPO}}/server:latest
+          docker build -t ${{secrets.DOCKER_REPO}}/server:0.62
+          docker push ${{secrets.DOCKER_REPO}}/server:0.62
   build_and_push_api_gateway:
     needs: setup
     runs-on: ubuntu-latest

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -42,8 +42,7 @@ jobs:
           path: ~/.docker/
       - name: Build and push server image
         run: |
-          cd Docker/server
-          docker build -t ${{secrets.DOCKER_REPO}}/server:0.62
+          docker buildx build -t ${{secrets.DOCKER_REPO}}/server:0.62 Docker/server
           docker push ${{secrets.DOCKER_REPO}}/server:0.62
   build_and_push_api_gateway:
     needs: setup
@@ -58,8 +57,7 @@ jobs:
           path: ~/.docker/
       - name: Build and push api_gateway image
         run: |
-          cd Docker/api_gateway
-          docker build -t ${{secrets.DOCKER_REPO}}/api_gateway:0.62
+          docker buildx build -t ${{secrets.DOCKER_REPO}}/api_gateway:0.62 Docker/api_gateway
           docker push ${{secrets.DOCKER_REPO}}/api_gateway:0.62
   build_and_push_mysql:
     needs: setup

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -90,7 +90,13 @@ jobs:
           docker tag nginx:1.25 ${{secrets.DOCKER_REPO}}/nginx:1.25
           docker push ${{secrets.DOCKER_REPO}}/nginx:1.25
   Deploy_to_server:
-    needs: [build_and_push_server, build_and_push_api_gateway]
+    needs:
+      [
+        build_and_push_server,
+        build_and_push_api_gateway,
+        build_and_push_mysql,
+        build_and_push_nginx,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: executing remote ssh commands using password
@@ -111,8 +117,4 @@ jobs:
             echo "$GONAGI_STORE_PEM" > gonagi.store.pem
             echo "$GONAGI_STORE_KEY_PEM" > gonagi.store-key.pem
             jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
-            cd ../server
-            sudo npm install
-            cd ../api_gateway
-            sudo npm install
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -78,19 +78,13 @@ jobs:
             cd pposonggil_v2
             sudo find . -type f -exec sed -i 's/localhost/gonagi.store/g' {} +   
             cd Docker/Keys
-            echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
-            echo "${{secrets.GONAGI_STORE_KEY_PEM}}" >> gonagi.store-key.pem
+            GONAGI_STORE_PEM="${{secrets.GONAGI_STORE_PEM}}"
+            GONAGI_STORE_KEY_PEM="${{secrets.GONAGI_STORE_KEY_PEM}}"
+            echo "$GONAGI_STORE_PEM" > gonagi.store.pem
+            echo "$GONAGI_STORE_KEY_PEM" > gonagi.store-key.pem
             jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
             cd ../server
             sudo npm install
             cd ../api_gateway
             sudo npm install
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/api_gateway:latest
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
-            sudo docker rmi nginx:1.25
-            sudo docker rmi mysql:8
-            sudo docker pull ${{secrets.DOCKER_REPO}}/api_gateway:latest
-            sudo docker pull ${{secrets.DOCKER_REPO}}/server:latest
-            sudo docker pull nginx:1.25
-            sudo docker pull mysql:8 
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -112,7 +112,16 @@ jobs:
             cd Docker/Keys
             echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
             echo "${{secrets.GONAGI_STORE_KEY_PEM}}" >> gonagi.store-key.pem
-            jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
+            echo "MYSQL_HOST=${{secrets.MYSQL_HOST}}" >> .env
+            echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
+            echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
+            echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" >>.env
+            echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
+            echo "PUBLIC_KEY=${{secrets.PUBLIC_KEY}}" >> .env
+            echo "ODSAY_KEY=${{secrets.ODSAY_KEY}}" >>.env
+            echo "KAKAO_JAVASCRIPT_KEY=${{secrets.KAKAO_JAVASCRIPT_KEY}}" >> .env
+            echo "KAKAO_REST_KEY=${{secrets.KAKAO_REST_KEY}}" >> .env
+            echo "SESSION_KEY=${{secrets.SESSION_KEY}}" >>.env
             cd ../server
             sudo npm install
             cd ../api_gateway

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -119,12 +119,4 @@ jobs:
             sudo npm install
             cd ../api_gateway
             sudo npm install
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/api_gateway:latest
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/nginx:1.25
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/mysql:8
-            sudo docker pull ${{secrets.DOCKER_REPO}}/api_gateway:latest
-            sudo docker pull ${{secrets.DOCKER_REPO}}/server:latest
-            sudo docker pull ${{secrets.DOCKER_REPO}}/nginx:1.25
-            sudo docker pull ${{secrets.DOCKER_REPO}}/mysql:8 
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -3,7 +3,7 @@ name: CI/CD
 on:
   pull_request:
     branches:
-      - develop
+      - feature-CICD
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -112,14 +112,18 @@ jobs:
             cd Docker/Keys
             echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
             echo "${{secrets.GONAGI_STORE_KEY_PEM}}" >> gonagi.store-key.pem
-            jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
+            echo "MYSQL_HOST=${{secrets.MYSQL_HOST}}" >> .env
+            echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
+            echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
+            echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" >>.env
+            echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
+            echo "PUBLIC_KEY=${{secrets.PUBLIC_KEY}}" >> .env
+            echo "ODSAY_KEY=${{secrets.ODSAY_KEY}}" >>.env
+            echo "KAKAO_JAVASCRIPT_KEY=${{secrets.KAKAO_JAVASCRIPT_KEY}}" >> .env
+            echo "KAKAO_REST_KEY=${{secrets.KAKAO_REST_KEY}}" >> .env
+            echo "SESSION_KEY=${{secrets.SESSION_KEY}}" >>.env
             cd ../server
             sudo npm install
             cd ../api_gateway
             sudo npm install            
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/api_gateway:latest
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/nginx:1.25
-            sudo docker rmi ${{secrets.DOCKER_REPO}}/mysql:8
-            sudo docker-compose pull
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -61,8 +61,42 @@ jobs:
           cd Docker/api_gateway
           docker build -t ${{secrets.DOCKER_REPO}}/api_gateway:latest .
           docker push ${{secrets.DOCKER_REPO}}/api_gateway:latest
+  build_and_push_mysql:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Docker token
+        uses: actions/download-artifact@v4.1.1
+        with:
+          name: docker-token
+          path: ~/.docker/
+      - name: Build and push mysql image
+        run: |
+          docker pull mysql:8
+          docker tag mysql:8 ${{secrets.DOCKER_REPO}}/mysql:8
+          docker push ${{secrets.DOCKER_REPO}}/mysql:8
+  build_and_push_nginx:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Docker token
+        uses: actions/download-artifact@v4.1.1
+        with:
+          name: docker-token
+          path: ~/.docker/
+      - name: Build and push nginx image
+        run: |
+          docker pull nginx:1.25
+          docker tag nginx:1.25 ${{secrets.DOCKER_REPO}}/nginx:1.25
+          docker push ${{secrets.DOCKER_REPO}}/nginx:1.25
   Deploy_to_server:
-    needs: [build_and_push_server, build_and_push_api_gateway]
+    needs:
+      [
+        build_and_push_server,
+        build_and_push_api_gateway,
+        build_and_push_mysql,
+        build_and_push_nginx,
+      ]
     runs-on: ubuntu-latest
     steps:
       - name: executing remote ssh commands using password
@@ -87,6 +121,6 @@ jobs:
             sudo npm install
             sudo docker rmi ${{secrets.DOCKER_REPO}}/api_gateway:latest
             sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
-            sudo docker rmi nginx:1.25
-            sudo docker rmi mysql:8
+            sudo docker rmi ${{secrets.DOCKER_REPO}}/nginx:1.25
+            sudo docker rmi ${{secrets.DOCKER_REPO}}/mysql:8
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -122,10 +122,6 @@ jobs:
             echo "KAKAO_JAVASCRIPT_KEY=${{secrets.KAKAO_JAVASCRIPT_KEY}}" >> .env
             echo "KAKAO_REST_KEY=${{secrets.KAKAO_REST_KEY}}" >> .env
             echo "SESSION_KEY=${{secrets.SESSION_KEY}}" >>.env
-            cd ../server
-            sudo npm install
-            cd ../api_gateway
-            sudo npm install
             sudo docker rmi ${{secrets.DOCKER_REPO}}/api_gateway:latest
             sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
             sudo docker rmi ${{secrets.DOCKER_REPO}}/nginx:1.25

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -1,7 +1,10 @@
 name: CI/CD
 
 on:
-  pull_request:
+  # pull_request:
+  #   branches:
+  #     - main
+  push:
     branches:
       - feature-CICD
 jobs:

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -83,8 +83,8 @@ jobs:
             echo "$GONAGI_STORE_PEM" > gonagi.store.pem
             echo "$GONAGI_STORE_KEY_PEM" > gonagi.store-key.pem
             jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
+            sudo docker-compose up -d
             cd ../server
             sudo npm install
             cd ../api_gateway
             sudo npm install
-            sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -112,16 +112,7 @@ jobs:
             cd Docker/Keys
             echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
             echo "${{secrets.GONAGI_STORE_KEY_PEM}}" >> gonagi.store-key.pem
-            echo "MYSQL_HOST=${{secrets.MYSQL_HOST}}" >> .env
-            echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
-            echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
-            echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" >>.env
-            echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
-            echo "PUBLIC_KEY=${{secrets.PUBLIC_KEY}}" >> .env
-            echo "ODSAY_KEY=${{secrets.ODSAY_KEY}}" >>.env
-            echo "KAKAO_JAVASCRIPT_KEY=${{secrets.KAKAO_JAVASCRIPT_KEY}}" >> .env
-            echo "KAKAO_REST_KEY=${{secrets.KAKAO_REST_KEY}}" >> .env
-            echo "SESSION_KEY=${{secrets.SESSION_KEY}}" >>.env
+            jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > Docker/Keys/.env
             cd ../server
             sudo npm install
             cd ../api_gateway

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -122,6 +122,10 @@ jobs:
             echo "KAKAO_JAVASCRIPT_KEY=${{secrets.KAKAO_JAVASCRIPT_KEY}}" >> .env
             echo "KAKAO_REST_KEY=${{secrets.KAKAO_REST_KEY}}" >> .env
             echo "SESSION_KEY=${{secrets.SESSION_KEY}}" >>.env
+            cd ../server
+            sudo npm install
+            cd ../api_gateway
+            sudo npm install            
             sudo docker rmi ${{secrets.DOCKER_REPO}}/api_gateway:latest
             sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
             sudo docker rmi ${{secrets.DOCKER_REPO}}/nginx:1.25

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -10,19 +10,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up .env file
+      - name: Create .env file
         run: |
-          cd Docker/Keys
-          echo "MYSQL_HOST=${{secrets.MYSQL_HOST}}" >> .env
-          echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
-          echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
-          echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" >>.env
-          echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
-          echo "PUBLIC_KEY=${{secrets.PUBLIC_KEY}}" >> .env
-          echo "ODSAY_KEY=${{secrets.ODSAY_KEY}}" >>.env
-          echo "KAKAO_JAVASCRIPT_KEY=${{secrets.KAKAO_JAVASCRIPT_KEY}}" >> .env
-          echo "KAKAO_REST_KEY=${{secrets.KAKAO_REST_KEY}}" >> .env
-          echo "SESSION_KEY=${{secrets.SESSION_KEY}}" >>.env
+          jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > Docker/Keys/.env
+        env:
+          SECRETS_CONTEXT: ${{ toJson(secrets) }}
       - name: Login Docker and save token
         id: docker_login
         uses: docker/login-action@v3.0.0
@@ -85,16 +77,7 @@ jobs:
             cd Docker/Keys
             echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
             echo "${{secrets.GONAGI_STORE_KEY_PEM}}" >> gonagi.store-key.pem
-            echo "MYSQL_HOST=${{secrets.MYSQL_HOST}}" >> .env
-            echo "MYSQL_USER=${{secrets.MYSQL_USER}}" >> .env
-            echo "MYSQL_DATABASE=${{secrets.MYSQL_DATABASE}}" >> .env
-            echo "MYSQL_ROOT_PASSWORD=${{secrets.MYSQL_ROOT_PASSWORD}}" >>.env
-            echo "MYSQL_PASSWORD=${{secrets.MYSQL_PASSWORD}}" >> .env
-            echo "PUBLIC_KEY=${{secrets.PUBLIC_KEY}}" >> .env
-            echo "ODSAY_KEY=${{secrets.ODSAY_KEY}}" >>.env
-            echo "KAKAO_JAVASCRIPT_KEY=${{secrets.KAKAO_JAVASCRIPT_KEY}}" >> .env
-            echo "KAKAO_REST_KEY=${{secrets.KAKAO_REST_KEY}}" >> .env
-            echo "SESSION_KEY=${{secrets.SESSION_KEY}}" >>.env
+            jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
             cd ../server
             sudo npm install
             cd ../api_gateway

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -86,5 +86,5 @@ jobs:
             GONAGI_STORE_KEY_PEM="${{secrets.GONAGI_STORE_KEY_PEM}}"
             echo "$GONAGI_STORE_PEM" > gonagi.store.pem
             echo "$GONAGI_STORE_KEY_PEM" > gonagi.store-key.pem
-            echo "${{ toJson(secrets) }}" > .env
+            jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
             sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -81,6 +81,10 @@ jobs:
             echo "${{secrets.GONAGI_STORE_PEM}}" >> gonagi.store.pem
             echo "${{secrets.GONAGI_STORE_KEY_PEM}}" >> gonagi.store-key.pem
             jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
+            cd ../server
+            sudo npm install
+            cd ../api_gateway
+            sudo npm install
             sudo docker rmi ${{secrets.DOCKER_REPO}}/api_gateway:latest
             sudo docker rmi ${{secrets.DOCKER_REPO}}/server:latest
             sudo docker rmi nginx:1.25

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -61,6 +61,34 @@ jobs:
           cd Docker/api_gateway
           docker build -t ${{secrets.DOCKER_REPO}}/api_gateway:latest .
           docker push ${{secrets.DOCKER_REPO}}/api_gateway:latest
+  build_and_push_mysql:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Docker token
+        uses: actions/download-artifact@v4.1.1
+        with:
+          name: docker-token
+          path: ~/.docker/
+      - name: Build and push mysql image
+        run: |
+          docker pull mysql:8
+          docker tag mysql:8 ${{secrets.DOCKER_REPO}}/mysql:8
+          docker push ${{secrets.DOCKER_REPO}}/mysql:8
+  build_and_push_nginx:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Docker token
+        uses: actions/download-artifact@v4.1.1
+        with:
+          name: docker-token
+          path: ~/.docker/
+      - name: Build and push nginx image
+        run: |
+          docker pull nginx:1.25
+          docker tag nginx:1.25 ${{secrets.DOCKER_REPO}}/nginx:1.25
+          docker push ${{secrets.DOCKER_REPO}}/nginx:1.25
   Deploy_to_server:
     needs: [build_and_push_server, build_and_push_api_gateway]
     runs-on: ubuntu-latest
@@ -83,8 +111,8 @@ jobs:
             echo "$GONAGI_STORE_PEM" > gonagi.store.pem
             echo "$GONAGI_STORE_KEY_PEM" > gonagi.store-key.pem
             jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
-            sudo docker-compose up -d
             cd ../server
             sudo npm install
             cd ../api_gateway
             sudo npm install
+            sudo docker-compose up -d

--- a/.github/workflows/CI_CD.yml
+++ b/.github/workflows/CI_CD.yml
@@ -61,42 +61,8 @@ jobs:
           cd Docker/api_gateway
           docker build -t ${{secrets.DOCKER_REPO}}/api_gateway:latest .
           docker push ${{secrets.DOCKER_REPO}}/api_gateway:latest
-  build_and_push_mysql:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Docker token
-        uses: actions/download-artifact@v4.1.1
-        with:
-          name: docker-token
-          path: ~/.docker/
-      - name: Build and push mysql image
-        run: |
-          docker pull mysql:8
-          docker tag mysql:8 ${{secrets.DOCKER_REPO}}/mysql:8
-          docker push ${{secrets.DOCKER_REPO}}/mysql:8
-  build_and_push_nginx:
-    needs: setup
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Docker token
-        uses: actions/download-artifact@v4.1.1
-        with:
-          name: docker-token
-          path: ~/.docker/
-      - name: Build and push nginx image
-        run: |
-          docker pull nginx:1.25
-          docker tag nginx:1.25 ${{secrets.DOCKER_REPO}}/nginx:1.25
-          docker push ${{secrets.DOCKER_REPO}}/nginx:1.25
   Deploy_to_server:
-    needs:
-      [
-        build_and_push_server,
-        build_and_push_api_gateway,
-        build_and_push_mysql,
-        build_and_push_nginx,
-      ]
+    needs: [build_and_push_server, build_and_push_api_gateway]
     runs-on: ubuntu-latest
     steps:
       - name: executing remote ssh commands using password
@@ -108,13 +74,17 @@ jobs:
           port: ${{secrets.AWS_PORT}}
           script: |
             sudo rm -rf pposonggil_v2
-            git clone https://github.com/Gonagi/pposonggil_v2.git 
+            git clone https://Gonagi:${{secrets.GONAGI_TOKEN}}@github.com/Gonagi/pposonggil_v2.git
             cd pposonggil_v2
-            sudo find . -type f -exec sed -i 's/localhost/gonagi.store/g' {} +   
-            cd Docker/Keys
+            sudo find . -type f -exec sed -i 's/localhost/gonagi.store/g' {} + 
+            cd Docker/server
+            sudo npm install
+            cd ../api_gateway
+            sudo npm install
+            cd ../Keys
             GONAGI_STORE_PEM="${{secrets.GONAGI_STORE_PEM}}"
             GONAGI_STORE_KEY_PEM="${{secrets.GONAGI_STORE_KEY_PEM}}"
             echo "$GONAGI_STORE_PEM" > gonagi.store.pem
             echo "$GONAGI_STORE_KEY_PEM" > gonagi.store-key.pem
-            jq -r 'to_entries|map("\(.key)=\(.value|tostring)")|.[]' <<< "$SECRETS_CONTEXT" > .env
+            echo "${{ toJson(secrets) }}" > .env
             sudo docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: nginx:1.25
+    image: gonaging/nginx:1.25
     container_name: nginx
     ports:
       - 80:80
@@ -22,11 +22,12 @@ services:
       - mysql
 
   server:
+    image: gonaging/server:latest
     depends_on:
       - mysql
     expose:
       - 8888
-    build: ./Docker/server
+    # build: ./Docker/server
     container_name: server
     restart: unless-stopped
     stdin_open: true # `-i`
@@ -41,11 +42,12 @@ services:
       - ./Docker/Keys:/usr/src/app/server/Keys
 
   api_gateway:
+    image: gonaging/api_gateway:latest
     depends_on:
       - mysql
     expose:
       - 8889
-    build: ./Docker/api_gateway
+    # build: ./Docker/api_gateway
     container_name: api_gateway
     restart: unless-stopped
     stdin_open: true # `-i`
@@ -60,7 +62,7 @@ services:
       - ./Docker/Keys:/usr/src/app/api_gateway/Keys
 
   mysql:
-    image: mysql:8
+    image: gonaging/mysql:8
     restart: unless-stopped
     env_file:
       - Docker/Keys/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: gonaging/nginx
+    image: gonaging/nginx:1.25
     container_name: nginx
     ports:
       - 80:80
@@ -62,14 +62,13 @@ services:
       - ./Docker/Keys:/usr/src/app/api_gateway/Keys
 
   mysql:
-    image: gonaging/mysql
+    image: gonaging/mysql:8
     restart: unless-stopped
     env_file:
       - Docker/Keys/.env
     container_name: mysqlDB
     expose:
       - 3306
-      - 33060
     environment:
       - TZ=Asia/Seoul
     command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: nginx:1.25
+    image: gonaging/nginx:1.25
     container_name: nginx
     ports:
       - 80:80
@@ -62,13 +62,13 @@ services:
       - ./Docker/Keys:/usr/src/app/api_gateway/Keys
 
   mysql:
-    image: mysql:8
+    image: gonaging/mysql:8
     restart: unless-stopped
     env_file:
       - Docker/Keys/.env
     container_name: mysqlDB
     expose:
-      - 33060:3306
+      - 3306
     environment:
       - TZ=Asia/Seoul
     command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: gonaging/nginx
+    image: nginx:1.25
     container_name: nginx
     ports:
       - 80:80
@@ -22,7 +22,6 @@ services:
       - mysql
 
   server:
-    image: gonaging/server
     depends_on:
       - mysql
     expose:
@@ -41,7 +40,6 @@ services:
       - ./Docker/Keys:/usr/src/app/server/Keys
 
   api_gateway:
-    image: gonaging/api_gateway
     depends_on:
       - mysql
     expose:
@@ -60,7 +58,7 @@ services:
       - ./Docker/Keys:/usr/src/app/api_gateway/Keys
 
   mysql:
-    image: gonaging/mysql
+    image: mysql:8
     restart: unless-stopped
     env_file:
       - Docker/Keys/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: gonaging/nginx:1.25
+    image: nginx:1.25
     container_name: nginx
     ports:
       - 80:80
@@ -62,7 +62,7 @@ services:
       - ./Docker/Keys:/usr/src/app/api_gateway/Keys
 
   mysql:
-    image: gonaging/mysql:8
+    image: mysql:8
     restart: unless-stopped
     env_file:
       - Docker/Keys/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: gonaging/nginx:1.25
+    image: gonaging/nginx
     container_name: nginx
     ports:
       - 80:80
@@ -22,7 +22,7 @@ services:
       - mysql
 
   server:
-    image: gonaging/server:latest
+    image: gonaging/server
     depends_on:
       - mysql
     expose:
@@ -42,7 +42,7 @@ services:
       - ./Docker/Keys:/usr/src/app/server/Keys
 
   api_gateway:
-    image: gonaging/api_gateway:latest
+    image: gonaging/api_gateway
     depends_on:
       - mysql
     expose:
@@ -62,7 +62,7 @@ services:
       - ./Docker/Keys:/usr/src/app/api_gateway/Keys
 
   mysql:
-    image: gonaging/mysql:8
+    image: gonaging/mysql
     restart: unless-stopped
     env_file:
       - Docker/Keys/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - mysql
     expose:
       - 8888
+    build: ./Docker/server
     container_name: server
     restart: unless-stopped
     stdin_open: true # `-i`
@@ -44,6 +45,7 @@ services:
       - mysql
     expose:
       - 8889
+    build: ./Docker/api_gateway
     container_name: api_gateway
     restart: unless-stopped
     stdin_open: true # `-i`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - mysql
     expose:
       - 8888
-    # build: ./Docker/server
+    build: ./Docker/server
     container_name: server
     restart: unless-stopped
     stdin_open: true # `-i`
@@ -47,7 +47,7 @@ services:
       - mysql
     expose:
       - 8889
-    # build: ./Docker/api_gateway
+    build: ./Docker/api_gateway
     container_name: api_gateway
     restart: unless-stopped
     stdin_open: true # `-i`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: gonaging/nginx
+    image: gonaging/nginx:1.25
     container_name: nginx
     ports:
       - 80:80
@@ -22,7 +22,7 @@ services:
       - mysql
 
   server:
-    image: gonaging/server
+    image: gonaging/server:latest
     depends_on:
       - mysql
     expose:
@@ -42,7 +42,7 @@ services:
       - ./Docker/Keys:/usr/src/app/server/Keys
 
   api_gateway:
-    image: gonaging/api_gateway
+    image: gonaging/api_gateway:latest
     depends_on:
       - mysql
     expose:
@@ -62,7 +62,7 @@ services:
       - ./Docker/Keys:/usr/src/app/api_gateway/Keys
 
   mysql:
-    image: gonaging/mysql
+    image: gonaging/mysql:8
     restart: unless-stopped
     env_file:
       - Docker/Keys/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: gonaging/nginx:0.62
+    image: gonaging/nginx
     container_name: nginx
     ports:
       - 80:80
@@ -22,7 +22,7 @@ services:
       - mysql
 
   server:
-    image: gonaging/server:0.62
+    image: gonaging/server
     depends_on:
       - mysql
     expose:
@@ -41,7 +41,7 @@ services:
       - ./Docker/Keys:/usr/src/app/server/Keys
 
   api_gateway:
-    image: gonaging/api_gateway:0.62
+    image: gonaging/api_gateway
     depends_on:
       - mysql
     expose:
@@ -60,7 +60,7 @@ services:
       - ./Docker/Keys:/usr/src/app/api_gateway/Keys
 
   mysql:
-    image: gonaging/mysql:0.62
+    image: gonaging/mysql
     restart: unless-stopped
     env_file:
       - Docker/Keys/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - mysql
 
   server:
-    image: gonaging/server:latest
+    image: gonaging/server:0.62
     depends_on:
       - mysql
     expose:
@@ -41,7 +41,7 @@ services:
       - ./Docker/Keys:/usr/src/app/server/Keys
 
   api_gateway:
-    image: gonaging/api_gateway:latest
+    image: gonaging/api_gateway:0.62
     depends_on:
       - mysql
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - mysql
 
   server:
-    image: gonaging/server:0.62
+    image: gonaging/server:latest
     depends_on:
       - mysql
     expose:
@@ -41,7 +41,7 @@ services:
       - ./Docker/Keys:/usr/src/app/server/Keys
 
   api_gateway:
-    image: gonaging/api_gateway:0.62
+    image: gonaging/api_gateway:latest
     depends_on:
       - mysql
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
     container_name: mysqlDB
     expose:
       - 3306
+      - 33060
     environment:
       - TZ=Asia/Seoul
     command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: nginx:1.25
+    image: gonaging/nginx:1.25
     container_name: nginx
     ports:
       - 80:80
@@ -22,6 +22,7 @@ services:
       - mysql
 
   server:
+    image: gonaging/server:latest
     depends_on:
       - mysql
     expose:
@@ -41,6 +42,7 @@ services:
       - ./Docker/Keys:/usr/src/app/server/Keys
 
   api_gateway:
+    image: gonaging/api_gateway:latest
     depends_on:
       - mysql
     expose:
@@ -60,7 +62,7 @@ services:
       - ./Docker/Keys:/usr/src/app/api_gateway/Keys
 
   mysql:
-    image: mysql:8
+    image: gonaging/mysql:8
     restart: unless-stopped
     env_file:
       - Docker/Keys/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: gonaging/nginx:1.25
+    image: gonaging/nginx:0.62
     container_name: nginx
     ports:
       - 80:80
@@ -22,12 +22,11 @@ services:
       - mysql
 
   server:
-    image: gonaging/server
+    image: gonaging/server:0.62
     depends_on:
       - mysql
     expose:
       - 8888
-    build: ./Docker/server
     container_name: server
     restart: unless-stopped
     stdin_open: true # `-i`
@@ -42,12 +41,11 @@ services:
       - ./Docker/Keys:/usr/src/app/server/Keys
 
   api_gateway:
-    image: gonaging/api_gateway:latest
+    image: gonaging/api_gateway:0.62
     depends_on:
       - mysql
     expose:
       - 8889
-    build: ./Docker/api_gateway
     container_name: api_gateway
     restart: unless-stopped
     stdin_open: true # `-i`
@@ -62,7 +60,7 @@ services:
       - ./Docker/Keys:/usr/src/app/api_gateway/Keys
 
   mysql:
-    image: gonaging/mysql:8
+    image: gonaging/mysql:0.62
     restart: unless-stopped
     env_file:
       - Docker/Keys/.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       - Docker/Keys/.env
     container_name: mysqlDB
     expose:
-      - 3306
+      - 33060:3306
     environment:
       - TZ=Asia/Seoul
     command:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: gonaging/nginx:1.25
+    image: gonaging/nginx
     container_name: nginx
     ports:
       - 80:80
@@ -22,7 +22,7 @@ services:
       - mysql
 
   server:
-    image: gonaging/server:latest
+    image: gonaging/server
     depends_on:
       - mysql
     expose:
@@ -62,7 +62,7 @@ services:
       - ./Docker/Keys:/usr/src/app/api_gateway/Keys
 
   mysql:
-    image: gonaging/mysql:8
+    image: gonaging/mysql
     restart: unless-stopped
     env_file:
       - Docker/Keys/.env


### PR DESCRIPTION
# Issue : #35 
### CI_CD.yml
- #### main 브랜치에 pull request가 발생할 때만 Github Action이 작동하도록 수정
- #### setup의 .env파일 만드는 코드 개선
- #### 멀티 아키텍쳐를 지원하는 buildx로 build하도록 수정(ARM, AMD 모두 지원)
  - [참고](https://gurumee92.tistory.com/311)
     <img width="247" alt="image" src="https://github.com/Gonagi/pposonggil_v2/assets/50358403/79a5b658-8c6e-4df5-94e2-efc7017fb2dd">

- #### 불필요한 이미지 삭제 대신에 'sudo docker-compose up -d'로 처리
### docker-compose.yml
- #### 직접 빌드하고 DockerHub에 push한 이미지를 pull 하도록 처리
  - #### 개선전
    - DockerHub에서 push한 'gonaging/' 이미지를 pull하지 않고 공식 이미지를 pull해서 컨테이너를 생성하였다.
      <img width="506" alt="image" src="https://github.com/Gonagi/pposonggil_v2/assets/50358403/852d7e7f-eb80-4672-948f-010f2148e072" width="500" height="160">
  - #### 개선후
    - ckerHub에 push한 이미지들만 pull (node 공식 이미지는 필수)
    - 실행중인 컨테이너를 보면 모두 gonaging 이미지인것을 확인할 수 있다.
      <img width="854" alt="image" src="https://github.com/Gonagi/pposonggil_v2/assets/50358403/9ee01961-dc75-4914-ade0-6e88b0f91506" width="450" height="140">
      <img width="606" alt="image" src="https://github.com/Gonagi/pposonggil_v2/assets/50358403/670d05b2-b8dd-45a3-a098-c235b0ebd2c4" width="500" height="160">
